### PR TITLE
Add manifest file for kubernetes

### DIFF
--- a/kubernetes/namespace.yaml
+++ b/kubernetes/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: godoc

--- a/kubernetes/redis-svc.yaml
+++ b/kubernetes/redis-svc.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: godoc
   labels:
     name: redis
-    role: db
+    role: cache
 spec:
   ports:
   - name: redis
@@ -13,5 +13,5 @@ spec:
     targetPort: 6379
   selector:
     name: redis
-    role: db
+    role: cache
   type: NodePort

--- a/kubernetes/redis-svc.yaml
+++ b/kubernetes/redis-svc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: godoc
+  labels:
+    name: redis
+    role: db
+spec:
+  ports:
+  - name: redis
+    port: 6379
+    targetPort: 6379
+  selector:
+    name: redis
+    role: db
+  type: NodePort

--- a/kubernetes/redis.yaml
+++ b/kubernetes/redis.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: godoc
   labels:
     name: redis
-    role: db
+    role: cache
 spec:
   minReadySeconds: 30
   strategy:
@@ -16,7 +16,7 @@ spec:
       name: redis
       labels:
         name: redis
-        role: db
+        role: cache
     spec:
       containers:
       - image: redis:3.2.8-alpine

--- a/kubernetes/redis.yaml
+++ b/kubernetes/redis.yaml
@@ -19,7 +19,7 @@ spec:
         role: db
     spec:
       containers:
-      - image: redis
+      - image: redis:3.2.8-alpine
         name: redis
         ports:
         - containerPort: 6379

--- a/kubernetes/redis.yaml
+++ b/kubernetes/redis.yaml
@@ -1,0 +1,25 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: godoc
+  labels:
+    name: redis
+    role: db
+spec:
+  minReadySeconds: 30
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  template:
+    metadata:
+      name: redis
+      labels:
+        name: redis
+        role: db
+    spec:
+      containers:
+      - image: redis
+        name: redis
+        ports:
+        - containerPort: 6379

--- a/kubernetes/server-svc.yaml
+++ b/kubernetes/server-svc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: server
+  namespace: godoc
+  labels:
+    name: server
+    role: web
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+  selector:
+    name: server
+    role: web
+type: LoadBalancer

--- a/kubernetes/server.yaml
+++ b/kubernetes/server.yaml
@@ -1,0 +1,35 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: server
+  namespace: godoc
+  labels:
+    name: server
+    role: web
+spec:
+  minReadySeconds: 30
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  template:
+    metadata:
+      name: server
+      labels:
+        name: server
+        role: web
+    spec:
+      imagePullSecrets:
+     - name: wantedlybotkey
+      containers:
+      - image: quay.io/wantedly/docker-godoc:latest
+        name: server
+        ports:
+        - containerPort: 8080
+        env:
+        - name: REDIS_URL
+          value: redis://redis:6379
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: dotenv
+              key: github-token

--- a/kubernetes/server.yaml
+++ b/kubernetes/server.yaml
@@ -19,7 +19,7 @@ spec:
         role: web
     spec:
       imagePullSecrets:
-     - name: wantedlybotkey
+      - name: wantedlybotkey
       containers:
       - image: quay.io/wantedly/docker-godoc:latest
         name: server


### PR DESCRIPTION
## WHY

Deploy to kubernetes cluster.

## WHAT

Add manifest files.

- Pods
  - server (gddo-server)
  - redis
- Services
  - server:80 (LoadBalancer)
  - redis:6379 (NodePort)