### PR TITLE
Add godoc-walker as cronjob

### DIFF
--- a/kubernetes/walker.yaml
+++ b/kubernetes/walker.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  labels:
+    app: walker
+    role: job
+  name: walker
+  namespace: godoc
+spec:
+  concurrencyPolicy: Allow
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: walker
+        role: job
+      name: walker
+    spec:
+      parallelism: 1
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            app: walker
+            role: job
+          name: walker
+        spec:
+          containers:
+          - env:
+            - name: REDIS_URL
+              value: redis://redis:6379/1
+            - name: GODOC_URL
+              value: http://godoc
+            envFrom:
+            - secretRef:
+                name: godoc
+            image: bgpat/godoc-walker:latest
+            imagePullPolicy: Always
+            name: godoc-walker
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+  schedule: '* * * * *'
+  successfulJobsHistoryLimit: 3

--- a/kubernetes/walker.yaml
+++ b/kubernetes/walker.yaml
@@ -34,7 +34,7 @@ spec:
               value: http://godoc
             envFrom:
             - secretRef:
-                name: godoc
+                name: dotenv
             image: bgpat/godoc-walker:latest
             imagePullPolicy: Always
             name: godoc-walker

--- a/kubernetes/walker.yaml
+++ b/kubernetes/walker.yaml
@@ -38,5 +38,5 @@ spec:
             name: godoc-walker
           dnsPolicy: ClusterFirst
           restartPolicy: Never
-  schedule: '* * * * *'
+  schedule: '*/5 * * * *'
   successfulJobsHistoryLimit: 3

--- a/kubernetes/walker.yaml
+++ b/kubernetes/walker.yaml
@@ -11,7 +11,6 @@ spec:
   failedJobsHistoryLimit: 1
   jobTemplate:
     metadata:
-      creationTimestamp: null
       labels:
         app: walker
         role: job
@@ -20,7 +19,6 @@ spec:
       parallelism: 1
       template:
         metadata:
-          creationTimestamp: null
           labels:
             app: walker
             role: job


### PR DESCRIPTION
## WHY

Now, godoc updates when requested manually.

## WHAT

[godoc-walker](https://github.com/bgpat/godoc-walker) updates owned GitHub repositories automatically.
I want to use this.