### PR TITLE
Fix godoc-walker

### DIFF
--- a/kubernetes/walker.yaml
+++ b/kubernetes/walker.yaml
@@ -28,8 +28,6 @@ spec:
           - env:
             - name: REDIS_URL
               value: redis://redis:6379/1
-            - name: GODOC_URL
-              value: http://godoc
             envFrom:
             - secretRef:
                 name: dotenv


### PR DESCRIPTION
## WHY

`godoc-walker` job was failed.
`$GODOC_URL` must be `http://<user>:<pass>@godoc:443`. https://github.com/wantedly/godoc/blob/05b40b487d20ed3aad5fa09cdae259c57e3882b4/kubernetes/godoc.yaml#L65

## WHAT

Remove `$GODOC_URL` from job manifest, and set that parameter in dotenv instead.